### PR TITLE
Removes typo in Custom HTML Page documentation

### DIFF
--- a/src/content/how-to/configuration-plugins/custom-html.md
+++ b/src/content/how-to/configuration-plugins/custom-html.md
@@ -10,7 +10,7 @@
 </head>
 <body>
   <!-- Angular Playground Root Element -->
-  <ap-root></app-root>
+  <ap-root></ap-root>
 </body>
 </html>
 ```


### PR DESCRIPTION
This fixes a typo in the Custom HTML Page documentation. The typo is also in the matching file in the doc directory but from the looks of it these are generated from the source so I left that untouched.